### PR TITLE
Swapped share for singleton so now compatible with 5.4.

### DIFF
--- a/src/JasperPHP/JasperPHPServiceProvider.php
+++ b/src/JasperPHP/JasperPHPServiceProvider.php
@@ -17,7 +17,7 @@ class JasperPHPServiceProvider extends ServiceProvider
     public function register()
     {
 
-        $this->app['jasperphp'] = $this->app->share(function () {
+        $this->app['jasperphp'] = $this->app->singleton('JasperPHP',function () {
             return new JasperPHP;
         });
 


### PR DESCRIPTION
share Method Removed

The share method has been removed from the container. This was a legacy method that has not been documented in several years. If you are using this method, you should begin using the  singleton method instead: